### PR TITLE
Have the pipeline push the image at its commit SHA.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ deploy:
 		exit 1; \
 	fi; \
 	docker login -u $(DOCKER_HUB_USERNAME) -p $(DOCKER_HUB_PASSWORD) && \
-	docker tag $(IMAGE_PATH):$(LATEST_COMMIT_SHA) $(IMAGE_PATH):latest && \
-	docker push $(IMAGE_PATH);
+	docker tag $(IMAGE_PATH):$(LATEST_COMMIT_SHA) && \
+	docker push $(IMAGE_PATH):$(LATEST_COMMIT_SHA);
 
 encrypt_env:
 	if [ -z "$(TRAVIS_GITHUB_TOKEN)" ]; \


### PR DESCRIPTION
Automated Docker builds will push at latest tag from master.